### PR TITLE
Fix Gatsby Plugin Image issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - run:

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,6 +68,7 @@ module.exports = {
     },
     'gatsby-plugin-netlify',
     'gatsby-plugin-sitemap',
+    'gatsby-plugin-image',
     'gatsby-plugin-sharp',
     {
       resolve: 'gatsby-source-filesystem',

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -33,7 +33,7 @@ export const PostCard: React.FC<PostCardProps> = ({ post, large = false }) => {
       {post.frontmatter.image && large && (
         <Link className="post-card-image-link" css={PostCardImageLink} to={post.fields.slug}>
           <PostCardImage className="post-card-image">
-            {post.frontmatter?.image?.childImageSharp?.fluid && (
+            {post.frontmatter?.image?.childImageSharp?.gatsbyImageData && (
               <GatsbyImage
                 alt={`${post.frontmatter.title} cover image`}
                 style={{ height: '100%' }}

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -69,7 +69,6 @@ const IndexPage: React.FC<IndexProps> = props => {
           className="site-header-background"
           Tag="section"
           {...bgImage}
-          preserveStackingContext
         >
           <div css={inner}>
             <SiteNav isHome />
@@ -131,9 +130,7 @@ export const pageQuery = graphql`
   query blogPageQuery($skip: Int!, $limit: Int!) {
     header: file(relativePath: { eq: "img/cover.jpg" }) {
       childImageSharp {
-        fluid(quality: 100, maxWidth: 1720) {
-          ...GatsbyImageSharpFluid
-        }
+        gatsbyImageData(quality: 100)
       }
     }
     allMarkdownRemark(


### PR DESCRIPTION
Noticed there was just one issue really:

1. GraphQL query was still using `fluid` instead of `gatsbyImageData`
2. `getImage` of `gatsby-plugin-image` expects `gatsbyImageData` and not `fluid`, so returns `undefined`.
3. Therefore, `convertToBgImage` returns `undefined`.
4. Because `bgImage` was `undefined`, `BackgroundImage` was not rendered, and your `SiteNav` etc are children of `BackgroundImage`.

Also flagging that Gatsby v4 also requires Node v14 and above, so I've updated the circleCI config.